### PR TITLE
Add Italian translations

### DIFF
--- a/src/locales.js
+++ b/src/locales.js
@@ -15,14 +15,17 @@ import ja from './locales/ja'
 
 import pt from './locales/pt'
 
+import it from './locales/it'
+
 /**
  * ✏️ Then add it to the list here:
  */
 export {
-  da,
-  de,
-  en,
-  fr,
-  ja,
-  pt
+	da,
+	de,
+	en,
+	fr,
+	ja,
+	pt,
+	it
 }

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -1,0 +1,232 @@
+/**
+ * Here we can import additional helper functions to assist in formatting our
+ * language. Feel free to add additional helper methods to libs/formats if it
+ * assists in creating good validation messages for your locale.
+ */
+import { sentence as s } from '../libs/formats'
+
+/**
+ * This is the ISO 639-1 and (optionally) ISO 639-2 language "tag".
+ * Some valid examples:
+ * zh
+ * zh-CN
+ * zh-HK
+ * en
+ * en-GB
+ */
+const locale = 'it'
+
+/**
+ * This is an object of functions that each produce valid responses. There's no
+ * need for these to be 1-1 with english, feel free to change the wording or
+ * use/not use any of the variables available in the object or the
+ * arguments for the message to make the most sense in your language and culture.
+ *
+ * The validation context object includes the following properties:
+ * {
+ *   args        // Array of rule arguments: between:5,10 (args are ['5', '10'])
+ *   name:       // The validation name to be used
+ *   value:      // The value of the field (do not mutate!),
+ *   vm: the     // FormulateInput instance this belongs to,
+ *   formValues: // If wrapped in a FormulateForm, the value of other form fields.
+ * }
+ */
+const localizedValidationMessages = {
+
+  /**
+   * Valid accepted value.
+   */
+	accepted: function ({ name }) {
+		return `Per favore, accetta il campo ${name}.`
+	},
+
+  /**
+   * The date is not after.
+   */
+	after: function ({ name, args }) {
+		if (Array.isArray(args) && args.length) {
+			return `${s(name)} deve essere una data successiva al ${args[0]}.`
+		}
+		return `${s(name)} deve essere una data successiva a quella attuale.`
+	},
+
+  /**
+   * The value is not a letter.
+   */
+	alpha: function ({ name }) {
+		return `${s(name)} può contenere solo lettere.`
+	},
+
+  /**
+   * Rule: checks if the value is alpha numeric
+   */
+	alphanumeric: function ({ name }) {
+		return `${s(name)} può contenere solo lettere e numeri.`
+	},
+
+  /**
+   * The date is not before.
+   */
+	before: function ({ name, args }) {
+		if (Array.isArray(args) && args.length) {
+			return `${s(name)} deve essere una data precedente al ${args[0]}.`
+		}
+		return `${s(name)} deve essere una data precedente a quella attuale.`
+	},
+
+  /**
+   * The value is not between two numbers or lengths
+   */
+	between: function ({ name, value, args }) {
+		if (!isNaN(value)) {
+			return `${s(name)} deve essere tra ${args[0]} e ${args[1]}.`
+		}
+		return `${s(name)} deve avere una lunghezza compresa tra ${args[0]} e ${args[1]} caratteri.`
+	},
+
+  /**
+   * The confirmation field does not match
+   */
+	confirm: function ({ name, args }) {
+		return `${s(name)} non corrisponde.`
+	},
+
+  /**
+   * Is not a valid date.
+   */
+	date: function ({ name, args }) {
+		if (Array.isArray(args) && args.length) {
+			return `${s(name)} non è una data valida. Per favore usa il formato ${args[0]}`
+		}
+		return `${s(name)} non è una data valida.`
+	},
+
+  /**
+   * The default render method for error messages.
+   */
+	default: function ({ name }) {
+		return `Questo campo non è valido.`
+	},
+
+  /**
+   * Is not a valid email address.
+   */
+	email: function ({ name, value }) {
+		if (!value) {
+			return 'Per favore, inserisci un indirizzo email valido.'
+		}
+		return `“${value}” non è un indirizzo email valido.`
+	},
+
+  /**
+   * Ends with specified value
+   */
+	endsWith: function ({ name, value }) {
+		if (!value) {
+			return `Questo campo non termina con un valore valido.`
+		}
+		return `“${value}” non termina con un valore valido.`
+	},
+
+  /**
+   * Value is an allowed value.
+   */
+	in: function ({ name, value }) {
+		if (typeof value === 'string' && value) {
+			return `“${s(value)}” non è un valore valido per il campo ${name}.`
+		}
+		return `${name} invalido.`
+	},
+
+  /**
+   * Value is not a match.
+   */
+	matches: function ({ name }) {
+		return `${s(name)} invalido.`
+	},
+
+  /**
+   * The maximum value allowed.
+   */
+	max: function ({ name, value, args }) {
+		if (Array.isArray(value)) {
+			return `Puoi selezionare al massimo ${args[0]} ${name}.`
+		}
+		const force = Array.isArray(args) && args[1] ? args[1] : false
+		if ((!isNaN(value) && force !== 'length') || force === 'value') {
+			return `${s(name)} deve essere inferiore o uguale a ${args[0]}.`
+		}
+		return `${s(name)} deve essere inferiore o uguale a ${args[0]} caratteri.`
+	},
+
+  /**
+   * The (field-level) error message for mime errors.
+   */
+	mime: function ({ name, args }) {
+		return `${s(name)} deve essere del tipo: ${args[0] || 'Nessun formato file autorizzato.'}`
+	},
+
+  /**
+   * The maximum value allowed.
+   */
+	min: function ({ name, value, args }) {
+		if (Array.isArray(value)) {
+			return `Devi selezionare almeno ${args[0]} ${name}.`
+		}
+		const force = Array.isArray(args) && args[1] ? args[1] : false
+		if ((!isNaN(value) && force !== 'length') || force === 'value') {
+			return `${s(name)} deve essere maggiore di ${args[0]}.`
+		}
+		return `${s(name)} deve essere più lungo di ${args[0]} caratteri.`
+	},
+
+  /**
+   * The field is not an allowed value
+   */
+	not: function ({ name, value }) {
+		return `“${value}” non è un valore valido per il campo ${name}.`
+	},
+
+  /**
+   * The field is not a number
+   */
+	number: function ({ name }) {
+		return `${s(name)} deve essere un numero.`
+	},
+
+  /**
+   * Required field.
+   */
+	required: function ({ name }) {
+		return `${s(name)} è un campo obbligatorio.`
+	},
+
+  /**
+   * Starts with specified value
+   */
+	startsWith: function ({ name, value }) {
+		if (!value) {
+			return `Questo campo non inizia con un valore valido.`
+		}
+		return `“${value}” non inizia con un valore valido.`
+	},
+
+  /**
+   * Value is not a url.
+   */
+	url: function ({ name }) {
+		return `Per favore inserisci un URL valido.`
+	}
+}
+
+/**
+ * This creates a vue-formulate plugin that can be imported and used on each
+ * project.
+ */
+export default function (instance) {
+	instance.extend({
+		locales: {
+			[locale]: localizedValidationMessages
+		}
+	})
+}

--- a/test/unit/it.test.js
+++ b/test/unit/it.test.js
@@ -1,0 +1,26 @@
+import * as locales from '@/locales'
+
+// ✏️  Edit these to be the localized language
+const locale = 'it'
+
+// ✏️  Edit your locale's name
+describe('Italian translation', () => {
+	it('exports a function', () => {
+		expect(typeof locales[locale]).toBe('function')
+	})
+
+	it('calls extend on the formulate instance', () => {
+		const instance = { extend: jest.fn() }
+		locales[locale](instance)
+		expect(instance.extend.mock.calls.length).toBe(1)
+	})
+
+	it('includes all the validation results that english does', () => {
+		const instance = { extend: jest.fn() }
+		locales.en(instance)
+		locales[locale](instance)
+		const englishMessages = Object.keys(instance.extend.mock.calls[0][0].locales.en)
+		const localizedMessages = Object.keys(instance.extend.mock.calls[1][0].locales[locale])
+		expect(englishMessages).toEqual(localizedMessages)
+	})
+})


### PR DESCRIPTION
This library looks greats, thank you!

A short note. Sometimes I opted for a less personal/conversational tone of voice to avoid problems with masculine/feminine articles and suffixes in Italian. 

For example, for this line:
````
`“${s(value)}” is not an allowed ${name}.` 
````
I preferred:
````
`“${s(value)}” non è un valore valido per il campo ${name}.` 
````
For which the literal translation would be something like:
````
`“${s(value)}” is not an allowed value for the field ${name}.`
````
Instead of:
````
`“${s(value)}” non è un/una ${name} valido/a.`
````

Hope it makes sense. I saw that in French you opted for the double article and suffix. Let me know if you prefer that style.
✌️

