### PR TITLE
Update nl.js for 'min' rule

### DIFF
--- a/src/locales/nl.js
+++ b/src/locales/nl.js
@@ -183,7 +183,7 @@ const localizedValidationMessages = {
     if ((!isNaN(value) && force !== 'length') || force === 'value') {
       return `${s(name)} moet groter zijn dan ${args[0]}.`
     }
-    return `${s(name)} moet meer dan ${args[0]} karakters bevatten.`
+    return `${s(name)} moet tenminste ${args[0]} karakters bevatten.`
   },
 
   /**


### PR DESCRIPTION
Fix translation for 'min': the new translation is better, actually the old one gave wrong results.